### PR TITLE
Data sync

### DIFF
--- a/src/main/kotlin/com/kotlindiscord/bot/APIUtils.kt
+++ b/src/main/kotlin/com/kotlindiscord/bot/APIUtils.kt
@@ -1,0 +1,25 @@
+package com.kotlindiscord.bot
+
+import com.gitlab.kordlib.core.entity.Member
+import com.gitlab.kordlib.core.entity.Role
+import com.kotlindiscord.api.client.models.RoleModel
+import com.kotlindiscord.api.client.models.UserModel
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toSet
+
+/**
+ * Given a [Role] object, turn it into a [RoleModel] for API use.
+ */
+fun Role.toModel(): RoleModel = RoleModel(id.longValue, name, color.hashCode())
+
+/**
+ * Given a [Member] object, turn it into a [UserModel] for API use.
+ *
+ * @param present Whether the member is currently present on the guild.
+ */
+suspend fun Member.toModel(present: Boolean = true): UserModel =
+    UserModel(
+        id.longValue, username, discriminator, avatar.url,
+        roles.map { it.id.longValue }.toSet(),
+        present
+    )

--- a/src/main/kotlin/com/kotlindiscord/bot/KDBot.kt
+++ b/src/main/kotlin/com/kotlindiscord/bot/KDBot.kt
@@ -30,6 +30,7 @@ suspend fun main(args: Array<String>) {
     bot.addExtension(FilterExtension::class)
     bot.addExtension(LoggingExtension::class)
     bot.addExtension(SubscriptionExtension::class)
+    bot.addExtension(SyncExtension::class)
     bot.addExtension(VerificationExtension::class)
 
     if (environment == "dev") {

--- a/src/main/kotlin/com/kotlindiscord/bot/extensions/SyncExtension.kt
+++ b/src/main/kotlin/com/kotlindiscord/bot/extensions/SyncExtension.kt
@@ -4,12 +4,15 @@ import com.gitlab.kordlib.core.behavior.channel.createEmbed
 import com.gitlab.kordlib.core.entity.channel.TextChannel
 import com.gitlab.kordlib.core.event.gateway.ReadyEvent
 import com.kotlindiscord.api.client.models.RoleModel
+import com.kotlindiscord.api.client.models.UserModel
 import com.kotlindiscord.bot.config.config
 import com.kotlindiscord.bot.enums.Channels
 import com.kotlindiscord.kord.extensions.ExtensibleBot
 import com.kotlindiscord.kord.extensions.events.EventHandler
 import com.kotlindiscord.kord.extensions.extensions.Extension
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.flow.toSet
 import mu.KotlinLogging
 
 /**
@@ -32,6 +35,7 @@ class SyncExtension(bot: ExtensibleBot) : Extension(bot) {
     @Suppress("UnusedPrivateMember")  // Odd way to point out unused function params, isn't it
     suspend fun initialSync(handler: EventHandler<ReadyEvent>, event: ReadyEvent) {
         val (rolesUpdated, rolesRemoved) = updateRoles()
+        val (usersUpdated, usersScrubbed) = updateUsers()
 
         (config.getChannel(Channels.ALERTS) as TextChannel)
             .createEmbed {
@@ -39,6 +43,9 @@ class SyncExtension(bot: ExtensibleBot) : Extension(bot) {
                 description = """
                     **Roles updated:** $rolesUpdated
                     **Roles removed:** $rolesRemoved
+                    
+                    **Users updated:** $usersUpdated
+                    **Users scrubbed:** $usersScrubbed
                 """.trimIndent()
             }
     }
@@ -77,5 +84,56 @@ class SyncExtension(bot: ExtensibleBot) : Extension(bot) {
         rolesToRemove.forEach { config.api.deleteRole(it) }
 
         return Pair(rolesToUpdate.size, rolesToRemove.size)
+    }
+
+    /**
+     * @suppress
+     */
+    suspend fun updateUsers(): Pair<Int, Int> {
+        val dbUsers = config.api.getUsers().map { it.id to it }.toMap()
+        val discordUsers = config.getGuild().members.toList().map { it.id.longValue to it }.toMap()
+        val usersToUpdate = mutableListOf<UserModel>()
+        val usersToScrub = mutableListOf<UserModel>()
+
+        for ((id, user) in discordUsers.entries) {
+            val dbUser = dbUsers[id]
+
+            if (dbUser == null) {
+                usersToUpdate.add(
+                    UserModel(
+                        id, user.username, user.discriminator, user.avatar.url,
+                        user.roles.map { it.id.longValue }.toSet()
+                    )
+                )
+            } else if (  // Check if there's anything to update
+                dbUser.username != user.username ||
+                dbUser.discriminator != user.discriminator ||
+                dbUser.avatarUrl != user.avatar.url ||
+                dbUser.roles != user.roles.map { it.id.longValue }.toSet()
+            ) {
+                usersToUpdate.add(
+                    UserModel(
+                        id, user.username, user.discriminator, user.avatar.url,
+                        user.roles.map { it.id.longValue }.toSet()
+                    )
+                )
+            }
+        }
+
+        for ((id, user) in dbUsers.entries) {
+            if (discordUsers[id] == null && user.present) {
+                usersToScrub.add(  // TODO: Think about mutability in API models?
+                    UserModel(
+                        user.id, user.username, user.discriminator,
+                        user.avatarUrl, user.roles, false
+                    )
+                )
+            }
+        }
+
+        usersToUpdate.forEach { config.api.upsertUser(it) }
+        usersToScrub.forEach { config.api.upsertUser(it) }
+
+        return Pair(usersToUpdate.size, usersToScrub.size)
     }
 }

--- a/src/main/kotlin/com/kotlindiscord/bot/extensions/SyncExtension.kt
+++ b/src/main/kotlin/com/kotlindiscord/bot/extensions/SyncExtension.kt
@@ -25,7 +25,6 @@ import com.kotlindiscord.kord.extensions.extensions.Extension
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.flow.toSet
-import mu.KotlinLogging
 
 /**
  * Extension in charge of keeping the database (on the site) updated with data from Discord.
@@ -35,7 +34,6 @@ import mu.KotlinLogging
  */
 class SyncExtension(bot: ExtensibleBot) : Extension(bot) {
     override val name: String = "sync"
-    private val logger = KotlinLogging.logger {}
 
     override suspend fun setup() {
         event<ReadyEvent> { action(::initialSync) }
@@ -132,16 +130,12 @@ class SyncExtension(bot: ExtensibleBot) : Extension(bot) {
             val dbRole = dbRoles[id]
 
             if (dbRole == null) {
-                rolesToUpdate.add(
-                    RoleModel(id, role.name, role.color.hashCode())
-                )
+                rolesToUpdate.add(role.toModel())
             } else if (  // Check if there's anything to update
                 role.color.hashCode() != dbRole.colour ||
                 role.name != dbRole.name
             ) {
-                rolesToUpdate.add(
-                    RoleModel(id, role.name, role.color.hashCode())
-                )
+                rolesToUpdate.add(role.toModel())
             }
         }
 
@@ -168,24 +162,14 @@ class SyncExtension(bot: ExtensibleBot) : Extension(bot) {
             val dbUser = dbUsers[id]
 
             if (dbUser == null) {
-                usersToUpdate.add(
-                    UserModel(
-                        id, user.username, user.discriminator, user.avatar.url,
-                        user.roles.map { it.id.longValue }.toSet()
-                    )
-                )
+                usersToUpdate.add(user.toModel())
             } else if (  // Check if there's anything to update
                 dbUser.username != user.username ||
                 dbUser.discriminator != user.discriminator ||
                 dbUser.avatarUrl != user.avatar.url ||
                 dbUser.roles != user.roles.map { it.id.longValue }.toSet()
             ) {
-                usersToUpdate.add(
-                    UserModel(
-                        id, user.username, user.discriminator, user.avatar.url,
-                        user.roles.map { it.id.longValue }.toSet()
-                    )
-                )
+                usersToUpdate.add(user.toModel())
             }
         }
 

--- a/src/main/kotlin/com/kotlindiscord/bot/extensions/SyncExtension.kt
+++ b/src/main/kotlin/com/kotlindiscord/bot/extensions/SyncExtension.kt
@@ -56,13 +56,20 @@ class SyncExtension(bot: ExtensibleBot) : Extension(bot) {
         (config.getChannel(Channels.ALERTS) as TextChannel)
             .createEmbed {
                 title = "Sync statistics"
-                description = """
-                    **Roles updated:** $rolesUpdated
-                    **Roles removed:** $rolesRemoved
-                    
-                    **Users updated:** $usersUpdated
-                    **Users scrubbed:** $usersScrubbed
-                """.trimIndent()
+
+                field {
+                    inline = false
+
+                    name = "Roles"
+                    value = "**Updated:** $rolesUpdated | **Removed:** $rolesRemoved"
+                }
+
+                field {
+                    inline = false
+
+                    name = "Users"
+                    value = "**Updated:** $usersUpdated | **Scrubbed:** $usersScrubbed"
+                }
             }
     }
 

--- a/src/main/kotlin/com/kotlindiscord/bot/extensions/SyncExtension.kt
+++ b/src/main/kotlin/com/kotlindiscord/bot/extensions/SyncExtension.kt
@@ -48,11 +48,8 @@ class SyncExtension(bot: ExtensibleBot) : Extension(bot) {
         event<UserUpdateEvent> { action { userUpdated(it.user) } }
     }
 
-    /**
-     * @suppress
-     */
     @Suppress("UnusedPrivateMember")  // Odd way to point out unused function params, isn't it
-    suspend fun initialSync(handler: EventHandler<ReadyEvent>, event: ReadyEvent) {
+    private suspend fun initialSync(handler: EventHandler<ReadyEvent>, event: ReadyEvent) {
         val (rolesUpdated, rolesRemoved) = updateRoles()
         val (usersUpdated, usersScrubbed) = updateUsers()
 
@@ -69,35 +66,23 @@ class SyncExtension(bot: ExtensibleBot) : Extension(bot) {
             }
     }
 
-    /**
-     * @suppress
-     */
     @Suppress("UnusedPrivateMember")
-    suspend fun roleUpdated(role: Role) {
+    private suspend fun roleUpdated(role: Role) {
         config.api.upsertRole(role.toModel())
     }
 
-    /**
-     * @suppress
-     */
     @Suppress("UnusedPrivateMember")
-    suspend fun roleDeleted(role: Snowflake) {
+    private suspend fun roleDeleted(role: Snowflake) {
         config.api.deleteRole(role.longValue)
     }
 
-    /**
-     * @suppress
-     */
     @Suppress("UnusedPrivateMember")
-    suspend fun memberUpdated(member: Member) {
+    private suspend fun memberUpdated(member: Member) {
         config.api.upsertUser(member.toModel())
     }
 
-    /**
-     * @suppress
-     */
     @Suppress("UnusedPrivateMember")
-    suspend fun memberLeft(user: User) {
+    private suspend fun memberLeft(user: User) {
         val dbUser = config.api.getUser(user.id.longValue) ?: return
 
         config.api.upsertUser(
@@ -105,11 +90,8 @@ class SyncExtension(bot: ExtensibleBot) : Extension(bot) {
         )
     }
 
-    /**
-     * @suppress
-     */
     @Suppress("UnusedPrivateMember")
-    suspend fun userUpdated(user: User) {
+    private suspend fun userUpdated(user: User) {
         val dbUser = config.api.getUser(user.id.longValue) ?: return
 
         config.api.upsertUser(
@@ -117,10 +99,7 @@ class SyncExtension(bot: ExtensibleBot) : Extension(bot) {
         )
     }
 
-    /**
-     * @suppress
-     */
-    suspend fun updateRoles(): Pair<Int, Int> {
+    private suspend fun updateRoles(): Pair<Int, Int> {
         val dbRoles = config.api.getRoles().map { it.id to it }.toMap()
         val discordRoles = config.getGuild().roles.toList().map { it.id.longValue to it }.toMap()
         val rolesToUpdate = mutableListOf<RoleModel>()
@@ -149,10 +128,7 @@ class SyncExtension(bot: ExtensibleBot) : Extension(bot) {
         return Pair(rolesToUpdate.size, rolesToRemove.size)
     }
 
-    /**
-     * @suppress
-     */
-    suspend fun updateUsers(): Pair<Int, Int> {
+    private suspend fun updateUsers(): Pair<Int, Int> {
         val dbUsers = config.api.getUsers().map { it.id to it }.toMap()
         val discordUsers = config.getGuild().members.toList().map { it.id.longValue to it }.toMap()
         val usersToUpdate = mutableListOf<UserModel>()

--- a/src/main/kotlin/com/kotlindiscord/bot/extensions/SyncExtension.kt
+++ b/src/main/kotlin/com/kotlindiscord/bot/extensions/SyncExtension.kt
@@ -1,0 +1,81 @@
+package com.kotlindiscord.bot.extensions
+
+import com.gitlab.kordlib.core.behavior.channel.createEmbed
+import com.gitlab.kordlib.core.entity.channel.TextChannel
+import com.gitlab.kordlib.core.event.gateway.ReadyEvent
+import com.kotlindiscord.api.client.models.RoleModel
+import com.kotlindiscord.bot.config.config
+import com.kotlindiscord.bot.enums.Channels
+import com.kotlindiscord.kord.extensions.ExtensibleBot
+import com.kotlindiscord.kord.extensions.events.EventHandler
+import com.kotlindiscord.kord.extensions.extensions.Extension
+import kotlinx.coroutines.flow.toList
+import mu.KotlinLogging
+
+/**
+ * Extension in charge of keeping the database (on the site) updated with data from Discord.
+ *
+ * This extension checks for changes that need to be made when the ReadyEvent happens, and
+ * sends changes to the site when a variety of events happen.
+ */
+class SyncExtension(bot: ExtensibleBot) : Extension(bot) {
+    override val name: String = "sync"
+    private val logger = KotlinLogging.logger {}
+
+    override suspend fun setup() {
+        event<ReadyEvent> { action(::initialSync) }
+    }
+
+    /**
+     * @suppress
+     */
+    @Suppress("UnusedPrivateMember")  // Odd way to point out unused function params, isn't it
+    suspend fun initialSync(handler: EventHandler<ReadyEvent>, event: ReadyEvent) {
+        val (rolesUpdated, rolesRemoved) = updateRoles()
+
+        (config.getChannel(Channels.ALERTS) as TextChannel)
+            .createEmbed {
+                title = "Sync statistics"
+                description = """
+                    **Roles updated:** $rolesUpdated
+                    **Roles removed:** $rolesRemoved
+                """.trimIndent()
+            }
+    }
+
+    /**
+     * @suppress
+     */
+    suspend fun updateRoles(): Pair<Int, Int> {
+        val dbRoles = config.api.getRoles().map { it.id to it }.toMap()
+        val discordRoles = config.getGuild().roles.toList().map { it.id.longValue to it }.toMap()
+        val rolesToUpdate = mutableListOf<RoleModel>()
+        val rolesToRemove = mutableListOf<Long>()
+
+        for ((id, role) in discordRoles.entries) {
+            val dbRole = dbRoles[id]
+
+            if (dbRole == null) {
+                rolesToUpdate.add(
+                    RoleModel(id, role.name, role.color.hashCode())
+                )
+            } else if (  // Check if there's anything to update
+                role.color.hashCode() != dbRole.colour ||
+                role.name != dbRole.name
+            ) {
+                rolesToUpdate.add(
+                    RoleModel(id, role.name, role.color.hashCode())
+                )
+            }
+        }
+
+        for (id in dbRoles.keys) {
+            discordRoles[id] ?: rolesToRemove.add(id)
+        }
+
+        rolesToUpdate.forEach { config.api.upsertRole(it) }
+        rolesToRemove.forEach { config.api.deleteRole(it) }
+
+        return Pair(rolesToUpdate.size, rolesToRemove.size)
+    }
+}


### PR DESCRIPTION
This pull request adds the following functionality:

* Initial synchronisation of users and roles when the bot connects
* Automatic synchronisations of users and roles as they appear, disappear and update

This keeps the site's database synchronised with what we have going on on Discord for the most part.